### PR TITLE
Use pythonnative to avoid host problems

### DIFF
--- a/meta-digi-dey/recipes-support/libsoc/libsoc_git.bb
+++ b/meta-digi-dey/recipes-support/libsoc/libsoc_git.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://github.com/jackmitch/libsoc"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=e0bfebea12a718922225ba987b2126a5"
 
-inherit autotools pkgconfig python-dir
+inherit autotools pkgconfig pythonnative
 
 SRCBRANCH ?= "master"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
Users using python virtual environments by default will not have pkg-config data and the build will fail. Use the native python to avoid issues and ensure consistency.